### PR TITLE
chore: update pystac to v1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find_namespace:
 include_package_data = True
 install_requires =
     stactools == 0.2.5
-    pystac @ git+https://github.com/stac-utils/pystac.git@5cff27dff6cf2cee8e8c58e21fee0f2b70ee42c7
+    pystac ~= 1.3.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
**Related Issue(s):** n/a

**Description:** We were using an unreleased version of pystac, but we don't have to now.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
