### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## [Unreleased]
+## [v0.2.0] - 2022-04-18
 
 ### Added
 
@@ -95,7 +95,8 @@ Initial commit.
 
 - Nothing.
 
-[Unreleased]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.1.4..main>
+[Unreleased]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.2.0..main>
+[0.2.0]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.1.4..v0.2.0>
 [0.1.4]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.1.3..v0.1.4>
 [0.1.3]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.1.2..v0.1.3>
 [0.1.2]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.1.1..v0.1.2>

--- a/src/stactools/noaa_c_cap/__init__.py
+++ b/src/stactools/noaa_c_cap/__init__.py
@@ -12,4 +12,4 @@ def register_plugin(registry):
 
 
 __all__ = ["Dataset"]
-__version__ = "0.1.4"
+__version__ = "0.2.0"


### PR DESCRIPTION
**Related Issue(s):**
None

**Description:**
https://test.pypi.org/project/stactools-noaa-c-cap/0.2.0/

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] `examples/` is updated to reflect new STAC objects, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).

## Release notes

```
v0.2.0

Added:

- `classification` extension ([#12](https://github.com/stactools-packages/noaa-c-cap/pull/12))
- `raster` extension and links ([#13](https://github.com/stactools-packages/noaa-c-cap/pull/13))
- pre-commit ([#13](https://github.com/stactools-packages/noaa-c-cap/pull/13))

Changed:

- All in [#12](https://github.com/stactools-packages/noaa-c-cap/pull/12):
    - Use `pytest` instead of `unittest`
    - Use `black` instead of `yapf`
    - Set datetime to `None`

Removed:

- `file` and `label` extensions ([#12](https://github.com/stactools-packages/noaa-c-cap/pull/12))
```