### PR TITLE
Remove GSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
+## [Unreleased]
+
+### Fixed
+
+- Removed leftover `gsd` attribute -- it is now in `raster:bands` ([#15](https://github.com/stactools-packages/noaa-c-cap/pull/15))
+
 ## [v0.2.0] - 2022-04-18
 
 ### Added

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -284,10 +284,5 @@
       ],
       "url": "https://coast.noaa.gov/digitalcoast/data/ccapregional.html"
     }
-  ],
-  "summaries": {
-    "gsd": [
-      30
-    ]
-  }
+  ]
 }

--- a/examples/conus_1975_ccap_landcover_20200311/conus_1975_ccap_landcover_20200311.json
+++ b/examples/conus_1975_ccap_landcover_20200311/conus_1975_ccap_landcover_20200311.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "1975-01-01T00:00:00Z",
     "end_datetime": "1975-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/conus_1985_ccap_landcover_20200311/conus_1985_ccap_landcover_20200311.json
+++ b/examples/conus_1985_ccap_landcover_20200311/conus_1985_ccap_landcover_20200311.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "1985-01-01T00:00:00Z",
     "end_datetime": "1985-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/conus_1992_ccap_landcover_20201019/conus_1992_ccap_landcover_20201019.json
+++ b/examples/conus_1992_ccap_landcover_20201019/conus_1992_ccap_landcover_20201019.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "1992-01-01T00:00:00Z",
     "end_datetime": "1992-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/conus_1996_ccap_landcover_20200311/conus_1996_ccap_landcover_20200311.json
+++ b/examples/conus_1996_ccap_landcover_20200311/conus_1996_ccap_landcover_20200311.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "1996-01-01T00:00:00Z",
     "end_datetime": "1996-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/conus_2001_ccap_landcover_20200311/conus_2001_ccap_landcover_20200311.json
+++ b/examples/conus_2001_ccap_landcover_20200311/conus_2001_ccap_landcover_20200311.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "2001-01-01T00:00:00Z",
     "end_datetime": "2001-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/conus_2006_ccap_landcover_20200311/conus_2006_ccap_landcover_20200311.json
+++ b/examples/conus_2006_ccap_landcover_20200311/conus_2006_ccap_landcover_20200311.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "2006-01-01T00:00:00Z",
     "end_datetime": "2006-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/conus_2010_ccap_landcover_20200311/conus_2010_ccap_landcover_20200311.json
+++ b/examples/conus_2010_ccap_landcover_20200311/conus_2010_ccap_landcover_20200311.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "2010-01-01T00:00:00Z",
     "end_datetime": "2010-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/conus_2016_ccap_landcover_20200311/conus_2016_ccap_landcover_20200311.json
+++ b/examples/conus_2016_ccap_landcover_20200311/conus_2016_ccap_landcover_20200311.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "2016-01-01T00:00:00Z",
     "end_datetime": "2016-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/hi_1992_mosaic_ccap_land_cover/hi_1992_mosaic_ccap_land_cover.json
+++ b/examples/hi_1992_mosaic_ccap_land_cover/hi_1992_mosaic_ccap_land_cover.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "1992-01-01T00:00:00Z",
     "end_datetime": "1992-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/hi_2001_mosaic_ccap_land_cover/hi_2001_mosaic_ccap_land_cover.json
+++ b/examples/hi_2001_mosaic_ccap_land_cover/hi_2001_mosaic_ccap_land_cover.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "2001-01-01T00:00:00Z",
     "end_datetime": "2001-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/hi_2005_mosaic_ccap_land_cover/hi_2005_mosaic_ccap_land_cover.json
+++ b/examples/hi_2005_mosaic_ccap_land_cover/hi_2005_mosaic_ccap_land_cover.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "2005-01-01T00:00:00Z",
     "end_datetime": "2005-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/examples/pr_2010_ccap_hr_land_cover20170214_30m/pr_2010_ccap_hr_land_cover20170214_30m.json
+++ b/examples/pr_2010_ccap_hr_land_cover20170214_30m/pr_2010_ccap_hr_land_cover20170214_30m.json
@@ -18,7 +18,6 @@
     ],
     "start_datetime": "2010-01-01T00:00:00Z",
     "end_datetime": "2010-12-31T00:00:00Z",
-    "gsd": 30,
     "datetime": null
   },
   "geometry": {

--- a/src/stactools/noaa_c_cap/stac.py
+++ b/src/stactools/noaa_c_cap/stac.py
@@ -40,7 +40,6 @@ def create_collection(hrefs: Optional[List[str]] = None) -> Collection:
     items = [create_item_from_dataset(dataset) for dataset in datasets]
     extent = Extent.from_items(items)
     summaries = Summaries.empty()
-    summaries.add("gsd", list(set(item.common_metadata.gsd for item in items)))
     collection = Collection(
         id=COLLECTION_ID,
         title=COLLECTION_TITLE,
@@ -113,7 +112,6 @@ def create_item_from_dataset(
     item.common_metadata.end_datetime = datetime.datetime(
         int(dataset.year), 12, 31, tzinfo=datetime.timezone.utc
     )
-    item.common_metadata.gsd = SPATIAL_RESOLUTION
 
     data = item.assets.get("data")
     assert data

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -21,7 +21,6 @@ class StacTest(unittest.TestCase):
         collection = stac.create_collection(hrefs)
         self.assertEqual(collection.id, "noaa-c-cap")
         self.assertEqual(collection.title, "C-CAP Regional Land Cover and Change")
-        self.assertEqual(collection.summaries.get_list("gsd"), [30])
         self.assertEqual(len(list(collection.get_all_items())), 1)
 
         item_assets = ItemAssetsExtension.ext(collection)
@@ -53,7 +52,7 @@ class StacTest(unittest.TestCase):
             item.common_metadata.end_datetime,
             datetime.datetime(2016, 12, 31, tzinfo=datetime.timezone.utc),
         )
-        self.assertEqual(item.common_metadata.gsd, 30)
+        self.assertIsNone(item.common_metadata.gsd)
         data = item.assets["data"]
         self.assertEqual(data.media_type, MediaType.COG)
         self.assertEqual(data.roles, ["data"])


### PR DESCRIPTION
**Related Issue(s):** None

**Description:**
GSD belongs in `raster:bands`, the item-level GSD was a mistake that should have been removed.

We'll call this non-breaking b/c bugfix :-)

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] `examples/` is updated to reflect new STAC objects, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
