### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## [Unreleased]
+## [v0.2.1] - 2022-04-19
 
 ### Fixed
 
@@ -101,7 +101,8 @@ Initial commit.
 
 - Nothing.
 
-[Unreleased]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.2.0..main>
+[Unreleased]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.2.1..main>
+[0.2.1]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.2.0..v0.2.1>
 [0.2.0]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.1.4..v0.2.0>
 [0.1.4]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.1.3..v0.1.4>
 [0.1.3]: <https://github.com/stactools-packages/noaa-c-cap/compare/v0.1.2..v0.1.3>

--- a/src/stactools/noaa_c_cap/__init__.py
+++ b/src/stactools/noaa_c_cap/__init__.py
@@ -12,4 +12,4 @@ def register_plugin(registry):
 
 
 __all__ = ["Dataset"]
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
**Related Issue(s):**
None

**Description:**
Removes GSD. It's a bugfix so we're calling it OK for a non-breaking change release.

https://test.pypi.org/project/stactools-noaa-c-cap/0.2.1/

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).

## Release notes

```
v0.2.1

Fixed:

- Removed leftover `gsd` attribute -- it is now in `raster:bands` ([#15](https://github.com/stactools-packages/noaa-c-cap/pull/15))
```